### PR TITLE
Allow merging of observable arrays

### DIFF
--- a/src/knockout.merge.js
+++ b/src/knockout.merge.js
@@ -16,25 +16,21 @@
 
     var knockoutElementMapping = function(knockoutElement, dataElement)
     {
-        if(typeof(knockoutElement.mergeConstructor) == "undefined")
-        {
-            if (!ko.isComputed(knockoutElement))
-            {
-                if(knockoutElement.mergeMethod)
-                { knockoutElement.mergeMethod(knockoutElement, dataElement); }
-                else if(knockoutElement.mergeRule)
-                {
+        if(typeof(knockoutElement.mergeConstructor) == "undefined") {
+            if (!ko.isComputed(knockoutElement)) {
+                if(knockoutElement.mergeMethod) { 
+                    knockoutElement.mergeMethod(knockoutElement, dataElement); 
+                } else if(knockoutElement.mergeRule) {
                     var mergeMethod = getMethodForMergeRule(knockoutElement.mergeRule);
                     if(mergeMethod) { mergeMethod(knockoutElement, dataElement); }
+                } else { 
+                    knockoutElement(dataElement); 
                 }
-                else
-                { knockoutElement(dataElement); }
             }
-        }
-        else
-        {
-            if(knockoutElement.replaceOnMerge)
-            { knockoutElement.removeAll(); }
+        } else {
+            if(knockoutElement.replaceOnMerge) { 
+                knockoutElement.removeAll(); 
+            }
 
             dataElement.forEach(function(element) {
                 var arrayElement = new knockoutElement.mergeConstructor();
@@ -56,22 +52,27 @@
         var isEmptyObject = (Object.keys(koModel).length == 0);
         for (var parameter in data)
         {
-            if (typeof (koModel[parameter]) == "object")
-            { exports.fromJS(koModel[parameter], data[parameter]); }
-            else if (typeof (koModel[parameter]) == "function")
-            { knockoutElementMapping(koModel[parameter], data[parameter]); }
-            else if(typeof(koModel[parameter]) != "undefined")
-            { koModel[parameter] = data[parameter]; }
-            else if(isEmptyObject)
-            { koModel[parameter] = data[parameter]; }
+            if (typeof (koModel[parameter]) == "object") { 
+                exports.fromJS(koModel[parameter], data[parameter]); 
+            }
+            else if (typeof (koModel[parameter]) == "function") { 
+                knockoutElementMapping(koModel[parameter], data[parameter]); 
+            }
+            else if(typeof(koModel[parameter]) != "undefined") { 
+                koModel[parameter] = data[parameter]; 
+            }
+            else if(isEmptyObject){ 
+                koModel[parameter] = data[parameter]; 
+            }
         }
     }
 
     ko.observableArray.fn.withMergeConstructor = function(mergeConstructor, replaceOnMerge) {
         this.mergeConstructor = mergeConstructor;
 
-        if(replaceOnMerge)
-        { this.replaceOnMerge = replaceOnMerge; }
+        if(replaceOnMerge) { 
+            this.replaceOnMerge = replaceOnMerge; 
+        }
 
         return this;
     }

--- a/src/knockout.merge.js
+++ b/src/knockout.merge.js
@@ -22,7 +22,21 @@
                     knockoutElement.mergeMethod(knockoutElement, dataElement); 
                 } else if(knockoutElement.mergeRule) {
                     var mergeMethod = getMethodForMergeRule(knockoutElement.mergeRule);
-                    if(mergeMethod) { mergeMethod(knockoutElement, dataElement); }
+                    if(mergeMethod) { 
+                        mergeMethod(knockoutElement, dataElement); 
+                    }
+                } else if(isObservableArray(knockoutElement) && isArray(dataElement)) {
+                    // If we have an observable array and a data element which is an array
+                    // then we need to merge the values item by item
+                    for(var i = 0; i < dataElement.length; i++) {
+                        if(i >= knockoutElement().length) {
+                            var placeholder = {};
+                            exports.fromJS(placeholder, dataElement[i]);
+                            knockoutElement.push(placeholder);
+                        } else {
+                            exports.fromJS(knockoutElement()[i], dataElement[i]);
+                        }
+                    }
                 } else { 
                     knockoutElement(dataElement); 
                 }
@@ -38,6 +52,17 @@
                 knockoutElement.push(arrayElement);
             });
         }
+    };
+
+    var isObservableArray = function(koElement) {
+        // Determine if the knockout element is an observable array - based upon
+        // impelemntation suggested at https://github.com/knockout/knockout/issues/619
+        return ko.isObservable(koElement) && !(koElement.destroyAll === undefined);
+    };
+
+    var isArray = function(dataElement) {
+        // Determine if the given data item is an array
+        return Object.prototype.toString.call(dataElement) === '[object Array]';
     };
 
     var getMethodForMergeRule = function(mergeRule) {


### PR DESCRIPTION
Have added the ability to merge `observableArrays` to fix https://github.com/grofit/knockout.merge/issues/6. Existing items will have their values merged (based on current index in the array) while any additional items will be added to the end of the array. The added objects however will be added just as POJO's.

Also fixed a few opening/close brackets not being on the correct lines.