### PR TITLE
Parameter with null value

### DIFF
--- a/src/knockout.merge.js
+++ b/src/knockout.merge.js
@@ -134,7 +134,7 @@
         {
             if(passToGlobalHandlers(koModel[parameter], data[parameter], options)) {
             }
-            else if (typeof (koModel[parameter]) == "object" &&
+            else if ((koModel[parameter] !== null && typeof (koModel[parameter]) == "object" &&
                 !(koModel[parameter] instanceof Date) &&
                 !isArray(koModel[parameter])) {
                 exports.fromJS(koModel[parameter], data[parameter], options);


### PR DESCRIPTION
Check whether an property is null, otherwise it will be treated as an object that needs to be recursed through.